### PR TITLE
Drop scroll shadow for Safari 13+

### DIFF
--- a/src/app/css/gadgets.css
+++ b/src/app/css/gadgets.css
@@ -6,7 +6,8 @@
 	overflow-y: auto;
 	-webkit-overflow-scrolling: touch; /* Safari 上啟用動能捲動 */
 
-	background-image:
+	/* Safari 13+ 不支援 local，先棄用這一段 */
+	/* background-image:
 		linear-gradient(white 30%, rgba(255, 255, 255, 0)),
 		linear-gradient(rgba(255, 255, 255, 0), white 70%),
 		radial-gradient(50% 0, farthest-side, rgba(0, 0, 0, 0.2), rgba(0, 0, 0, 0)),
@@ -19,10 +20,10 @@
 		radial-gradient(farthest-side at 50% 100%, rgba(0, 0, 0, 0.2), rgba(0, 0, 0, 0));
 
 	background-repeat: no-repeat;
-	background-color: white;
 	background-size: 100% 40px, 100% 40px, 100% 14px, 100% 14px;
 	background-position: 0 0, 0 100%, 0 0, 0 100%;
-	background-attachment: local, local, scroll, scroll;
+	background-attachment: local, local, scroll, scroll; */
+	background-color: white;
 }
 
 .scroll-shadow,

--- a/src/public/index.htm
+++ b/src/public/index.htm
@@ -32,7 +32,7 @@
 			page_title: document.title,
 			page_path: "/",
 			app_name: document.title,
-			app_version: "1218"
+			app_version: "1219"
 		};
 		gtag('js', new Date());
 		gtag('config', 'G-GG1TEZGBCQ', app_config);

--- a/src/theme/darkmode.scss
+++ b/src/theme/darkmode.scss
@@ -26,15 +26,15 @@ html.dark {
 	}
 
 	.scroll-shadow {
-		background-image: linear-gradient($modal 30%, rgba(255, 255, 255, 0)),
-			linear-gradient(rgba(255, 255, 255, 0), $modal 70%),
-			radial-gradient(50% 0, farthest-side, rgba(255, 255, 255, 0.2), rgba(0, 0, 0, 0)),
-			radial-gradient(50% 100%, farthest-side, rgba(255, 255, 255, 0.2), rgba(0, 0, 0, 0));
+		// background-image: linear-gradient($modal 30%, rgba(255, 255, 255, 0)),
+		// 	linear-gradient(rgba(255, 255, 255, 0), $modal 70%),
+		// 	radial-gradient(50% 0, farthest-side, rgba(255, 255, 255, 0.2), rgba(0, 0, 0, 0)),
+		// 	radial-gradient(50% 100%, farthest-side, rgba(255, 255, 255, 0.2), rgba(0, 0, 0, 0));
 
-		background-image: linear-gradient($modal 30%, rgba(255, 255, 255, 0)),
-			linear-gradient(rgba(255, 255, 255, 0), $modal 70%),
-			radial-gradient(farthest-side at 50% 0, rgba(255, 255, 255, 0.2), rgba(0, 0, 0, 0)),
-			radial-gradient(farthest-side at 50% 100%, rgba(255, 255, 255, 0.2), rgba(0, 0, 0, 0));
+		// background-image: linear-gradient($modal 30%, rgba(255, 255, 255, 0)),
+		// 	linear-gradient(rgba(255, 255, 255, 0), $modal 70%),
+		// 	radial-gradient(farthest-side at 50% 0, rgba(255, 255, 255, 0.2), rgba(0, 0, 0, 0)),
+		// 	radial-gradient(farthest-side at 50% 100%, rgba(255, 255, 255, 0.2), rgba(0, 0, 0, 0));
 
 		background-color: $modal;
 	}


### PR DESCRIPTION
Safari 13+ has a known bug that causes `background-attachment: local` to have no effect. This PR removes the scroll shadow for now as there's no simple way to fix this for Safari alone.